### PR TITLE
Automate user secrets setup and add .env file support with updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,7 @@ The environment is configured in the `config/main` file. Below are the key setti
    Click **"Use this template"** to create your repository. Name the repository to match the module name defined in the configuration file.  
    **Example:** If your module is `module-a`, name the repository `module-a`.
 
-4. **Set Up Action Secrets:**  
-   Go to **Settings → Actions → Secrets** in your new repository and add:  
-   - **`USER`**: Your username (e.g., `comp01`)  
-   - **`PASS`**: Your password (e.g., `test123`)
-
-5. **Test the Setup:**  
+4. **Test the Setup:**  
    Make a commit to verify that GitHub Actions are working correctly.
 
 ### Cloning and using the Repository

--- a/init.sh
+++ b/init.sh
@@ -99,6 +99,23 @@ tail -n +6 config/main | while read -r user pass sub; do
   docker exec gitea su -c '/app/gitea/gitea admin user create --username '$user' --password '$pass' --email '$user@example.com' --must-change-password=false' git
   ./add_user_to_team.sh $GITEA_URL $GITEA_TOKEN "frameworks" "competitors" ${user}
 
+  # Create user-level secrets for this user
+  echo "Creating user-level secrets for $user..."
+
+  # Create USER secret
+  curl -s -k -X PUT \
+    -u "$user:$pass" \
+    -H "Content-Type: application/json" \
+    -d "{\"data\": \"$user\"}" \
+    "$GITEA_URL/api/v1/user/actions/secrets/USER"
+  
+  # Create PASS secret  
+  curl -s -k -X PUT \
+    -u "$user:$pass" \
+    -H "Content-Type: application/json" \
+    -d "{\"data\": \"$pass\"}" \
+    "$GITEA_URL/api/v1/user/actions/secrets/PASS"
+
   for module in $MODULES; do
     echo "Processing module: $module for $user"
 

--- a/init.sh
+++ b/init.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Read the username and password from the config/main file
-DOMAIN=$(sed -n '1p' config/main)
-ENABLE_HTTPS=$(sed -n '2p' config/main)
-USERNAME=$(sed -n '3p' config/main)
-PASSWORD=$(sed -n '4p' config/main)
-MODULES=$(sed -n '5p' config/main)
+DOMAIN=$(sed -n '1p' config/main | tr -d '\r\n')
+ENABLE_HTTPS=$(sed -n '2p' config/main | tr -d '\r\n')
+USERNAME=$(sed -n '3p' config/main | tr -d '\r\n')
+PASSWORD=$(sed -n '4p' config/main | tr -d '\r\n')
+MODULES=$(sed -n '5p' config/main | tr -d '\r\n')
 
 export GITEA_HOSTNAME=$DOMAIN
 export ENABLE_HTTPS=$ENABLE_HTTPS
@@ -147,4 +147,20 @@ USERNAME=$USERNAME PASSWORD=$PASSWORD DOMAIN=$DOMAIN docker compose -f watchtowe
 # Start competitors work
 docker compose -f competitors.yaml up -d 
 
+# Write out environment variables to .env
+cat <<EOF > .env
+DOMAIN="$DOMAIN"
+ENABLE_HTTPS="$ENABLE_HTTPS"
+USERNAME="$USERNAME"
+PASSWORD="$PASSWORD"
+MODULES="$MODULES"
+GITEA_HOSTNAME="$GITEA_HOSTNAME"
+MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD"
+ENTRYPOINT="$ENTRYPOINT"
+GITEA_PROTOCOL="$GITEA_PROTOCOL"
+REGISTRY_PORT="$REGISTRY_PORT"
+REGISTRATION_TOKEN="$REGISTRATION_TOKEN"
+EOF
+
 echo "..all done!"
+


### PR DESCRIPTION
This pull request streamlines the setup process for user secrets and environment variables, improving automation and documentation. The most significant changes are the automatic creation of user-level secrets during initialization, the removal of manual secret setup steps from the documentation, and the addition of an `.env` file for environment variables.

**Automation of user secrets and environment variables:**

* The initialization script (`init.sh`) now automatically creates user-level secrets (`USER` and `PASS`) for each user using the Gitea API, removing the need for manual configuration.
* The script writes all relevant environment variables to a new `.env` file, making it easier to manage and reference configuration values.

**Documentation updates:**

* The README has been updated to remove the step instructing users to manually set up action secrets, reflecting the new automated approach.

**Code quality improvements:**

* The script now strips carriage returns and newlines from values read from `config/main` to prevent formatting issues.