### PR TITLE
Changes done after WSFR 48 competition

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 DOMAIN=$(sed -n '1p' config/main)
 
+
+echo Cleaning docker compose containers
 docker compose -f watchtower.yaml down
 docker compose -f competitors.yaml down
 docker compose -f mysql.yaml down
@@ -13,11 +15,10 @@ rm -rf ./data
 
 # go through all competitors and remove all images
 tail -n +5 config/main | while read -r user pass sub; do
-  echo $user
-  docker images | grep $user | awk '{print $3}' | xargs docker rmi -f
+  echo Cleaning $user images
+  docker images | grep $user | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f
 done
+echo Cleaning framework folders
+rm -rf /tmp/skill17
 
-rm -rf laravel
-rm -rf vuejs
-rm -rf react
-rm -rf vanillajs
+echo 'Everything has been cleaned successfully'

--- a/config/verdaccio/config.yaml
+++ b/config/verdaccio/config.yaml
@@ -1,0 +1,16 @@
+storage: /verdaccio/storage
+auth:
+  htpasswd:
+    file: ./htpasswd
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+  '**':
+    access: $all
+    proxy: npmjs
+log: { type: stdout, format: pretty, level: http }

--- a/generate-runners.sh
+++ b/generate-runners.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# ============================
+# generate-runners.sh
+# Dynamically generate Gitea runners in a docker-compose.yml file
+# Usage: ./generate-runners.sh <number_of_runners>
+# Example: ./generate-runners.sh 6
+# ============================
+
+set -e
+
+NUM_RUNNERS=$1
+
+if [[ -z "$NUM_RUNNERS" || "$NUM_RUNNERS" -lt 1 ]]; then
+  echo "Usage: $0 <number_of_runners>"
+  exit 1
+fi
+
+OUTPUT_FILE="gitea-runner.yaml"
+
+cat > "$OUTPUT_FILE" <<EOF
+services:
+  runner1: &runner
+    image: gitea/act_runner:latest
+    networks:
+      - gitea
+    environment: &runner_env
+      CONFIG_FILE: /config.yaml
+      GITEA_INSTANCE_URL: "http://gitea:3000"
+      GITEA_RUNNER_REGISTRATION_TOKEN: "\${REGISTRATION_TOKEN}"
+      GITEA_RUNNER_NAME: "Runner 1"
+    restart: always
+    volumes:
+      - ./config/gitea-runner/config.yaml:/config.yaml
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data/runner1:/data
+EOF
+
+# Generate remaining runners
+for i in $(seq 2 "$NUM_RUNNERS"); do
+cat >> "$OUTPUT_FILE" <<EOF
+
+  runner${i}:
+    <<: *runner
+    environment:
+      <<: *runner_env
+      GITEA_RUNNER_NAME: "Runner ${i}"
+    restart: always
+    volumes:
+      - ./config/gitea-runner/config.yaml:/config.yaml
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./data/runner${i}:/data
+EOF
+done
+
+cat >> "$OUTPUT_FILE" <<EOF
+
+networks:
+  gitea:
+    external: true
+EOF
+
+echo "✅ Generated $OUTPUT_FILE with $NUM_RUNNERS runners."

--- a/gitea.yaml
+++ b/gitea.yaml
@@ -21,6 +21,7 @@ services:
       # - ./scripts:/scripts
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+      - ./config/traefik/certs/ca-cert.crt:/usr/local/share/ca-certificates/ca-cert.crt:ro
     environment:
       # - GITEA__SERVER__ROOT_URL=https://git.${GITEA_HOSTNAME} 
       - GITEA__SERVER__ROOT_URL=${GITEA_PROTOCOL}://git.${GITEA_HOSTNAME} 

--- a/import_framework.sh
+++ b/import_framework.sh
@@ -16,17 +16,19 @@ REPO_NAME=$6
 WORKFLOW_FILE='docker-ci.yml'
 ORG_NAME='frameworks'
 
+mkdir -p /tmp/skill17
+
 # Clone the repository
-git clone "$GITHUB_URL" "$REPO_NAME"
-cd "$REPO_NAME" || exit
+git clone "$GITHUB_URL" /tmp/skill17/"$REPO_NAME"
+cd /tmp/skill17/"$REPO_NAME" || exit
 
 # Replace the URL in the GitHub Action file
 # sed -i '' "s|git.local.skill17.com|$GITEA_URL|g" ".github/workflows/$WORKFLOW_FILE"
 sed -i "s|git.local.skill17.com|$GITEA_URL|g" ".github/workflows/$WORKFLOW_FILE"
 
 # Configure git
-git config user.name "Franz Bot"
-git config user.email "franz@skill17.com"
+git config user.name "skill17"
+git config user.email "bot@skill17.com"
 
 # Commit the changes
 git add ".github/workflows/$WORKFLOW_FILE"

--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,11 @@ USERNAME=$(sed -n '3p' config/main | tr -d '\r\n')
 PASSWORD=$(sed -n '4p' config/main | tr -d '\r\n')
 MODULES=$(sed -n '5p' config/main | tr -d '\r\n')
 
+mkdir -p "/etc/docker/certs.d/git.$DOMAIN:443/"
+cp ./config/traefik/certs/ca-cert.crt /etc/docker/certs.d/git.$DOMAIN:443/
+
+systemctl restart docker
+
 export GITEA_HOSTNAME=$DOMAIN
 export ENABLE_HTTPS=$ENABLE_HTTPS
 export MYSQL_ROOT_PASSWORD=$PASSWORD
@@ -55,6 +60,13 @@ export REGISTRATION_TOKEN=$REGISTRATION_TOKEN
 
 echo "Registration Token: $REGISTRATION_TOKEN"
 
+# Generating the runner yaml configuration
+ echo "Generating the runners docker configuration"
+
+comps_nb=$(tail -n +6 config/main | wc -l)
+nb_runners=$((comps_nb*2))
+ ./generate-runners.sh $nb_runners
+
 # Start the Gitea runner with the registration token
 REGISTRATION_TOKEN=$REGISTRATION_TOKEN docker compose -f gitea-runner.yaml up -d
 
@@ -82,6 +94,14 @@ response=$(curl -s -k -X POST "$GITEA_URL/api/v1/orgs" \
 ./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/skill-setup/vanilla-base.git" "vanillajs"
 ./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/skill-setup/next-js-base.git" "nextjs"
 
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-nuxt-base" "nuxt-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-express-base" "express-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-solidjs-dev" "solidjs-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-elysia-base" "elysia-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-solidstart-base" "solidstart-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-next-base" "next-base"
+./import_framework.sh $GITEA_TOKEN $USERNAME $PASSWORD "git.$DOMAIN" "https://github.com/Ayce45/wsfr2025-elysia-prisma-base" "elysia-prisma-base"
+
 docker pull nginx:latest > /dev/null 2>&1
 docker login -u $USERNAME -p $PASSWORD git.$DOMAIN > /dev/null 2>&1
 
@@ -94,6 +114,8 @@ cat <<EOF > config/mysql/competitors.sql
 EOF
 
 # initialize the basic modules
+user_num=1
+
 tail -n +6 config/main | while read -r user pass sub; do
 
   docker exec gitea su -c '/app/gitea/gitea admin user create --username '$user' --password '$pass' --email '$user@example.com' --must-change-password=false' git
@@ -101,7 +123,6 @@ tail -n +6 config/main | while read -r user pass sub; do
 
   # Create user-level secrets for this user
   echo "Creating user-level secrets for $user..."
-
   # Create USER secret
   curl -s -k -X PUT \
     -u "$user:$pass" \
@@ -123,7 +144,7 @@ tail -n +6 config/main | while read -r user pass sub; do
   ${user}_${module}:
     image: git.${DOMAIN}/${user}/${module}:latest
     container_name: ${user}_${module}
-    restart: always
+    restart: on-failure:2
     networks:
       - gitea
     labels:
@@ -132,6 +153,8 @@ tail -n +6 config/main | while read -r user pass sub; do
       - "traefik.http.routers.${user}_${module}.entrypoints=${ENTRYPOINT}"
       - "traefik.http.routers.${user}_${module}.tls=${ENABLE_HTTPS}"
       - "traefik.http.services.${user}_${module}.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.${user}_${module}-ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 10.48.17.1${user_num}/32, 10.48.17.64/26, 10.48.17.128/25"
+      - "traefik.http.routers.${user}_${module}.middlewares=${user}_${module}-ipallowlist"
       - "com.centurylinklabs.watchtower.enable=true"
 EOF
     
@@ -146,7 +169,25 @@ EOF
 EOF
 
   done
+  user_num=$((user_num+1))
 done
+
+  # Create user-level secrets for root
+  echo "Creating user-level secrets for root..."
+  # Create USER secret
+  curl -s -k -X PUT \
+    -u "$USERNAME:$PASSWORD" \
+    -H "Content-Type: application/json" \
+    -d "{\"data\": \"$USERNAME\"}" \
+    "$GITEA_URL/api/v1/user/actions/secrets/USER"
+  
+  # Create PASS secret  
+  curl -s -k -X PUT \
+    -u "$USERNAME:$PASSWORD" \
+    -H "Content-Type: application/json" \
+    -d "{\"data\": \"$PASSWORD\"}" \
+    "$GITEA_URL/api/v1/user/actions/secrets/PASS"
+
 
 cat <<EOF >> competitors.yaml
 
@@ -170,6 +211,8 @@ chmod 777 -R ./data/verdaccio
 # Start competitors work
 docker compose -f competitors.yaml up -d 
 
+# Start system containers
+docker compose -f system.yaml up -d
 # Write out environment variables to .env
 cat <<EOF > .env
 DOMAIN="$DOMAIN"
@@ -183,6 +226,7 @@ ENTRYPOINT="$ENTRYPOINT"
 GITEA_PROTOCOL="$GITEA_PROTOCOL"
 REGISTRY_PORT="$REGISTRY_PORT"
 REGISTRATION_TOKEN="$REGISTRATION_TOKEN"
+GITEA_TOKEN="$GITEA_TOKEN"
 EOF
 
 echo "..all done!"

--- a/system.yaml
+++ b/system.yaml
@@ -1,0 +1,48 @@
+services:
+  cdn:
+    image: git.server.skill17/root/cdn
+    container_name: cdn
+    restart: on-failure:2
+    networks:
+      - gitea
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.cdn.rule=Host(`cdn.server.skill17`)"
+      - "traefik.http.routers.cdn.entrypoints=websecure"
+      - "traefik.http.routers.cdn.tls=true"
+      - "traefik.http.services.cdn.loadbalancer.server.port=80"
+      - "traefik.http.routers.cdn.middlewares=corsall"
+      - "traefik.http.middlewares.corsall.headers.accesscontrolallowmethods=GET,OPTIONS,PUT,POST,DELETE"
+      - "traefik.http.middlewares.corsall.headers.accesscontrolallowheaders=*"
+      - "traefik.http.middlewares.corsall.headers.accesscontrolalloworiginlist=*"
+      - "traefik.http.middlewares.corsall.headers.accesscontrolmaxage=100"
+      - "traefik.http.middlewares.corsall.headers.addvaryheader=true"
+
+#      - "traefik.http.routers.cdn.middlewares=cdn_auth"
+#      - "traefik.http.routers.cdn.middlewares=cdn_ipallowlist"
+#      - "traefik.http.middlewares.cdn_auth.basicauth.users=root:$$2y$$05$$X5YxScZkW9geqHY631Mx1.jdbiCLOFSOyLk61c/753RDjCJKuCLvu"
+#      - "traefik.http.middlewares.cdn_ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 10.48.17.64/26, 10.48.17.128/25"
+      - "com.centurylinklabs.watchtower.enable=true"
+  api:
+    image: git.server.skill17/root/api
+    container_name: api
+    restart: on-failure:2
+    networks:
+      - gitea
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`api.server.skill17`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls=true"
+      - "traefik.http.services.api.loadbalancer.server.port=80"
+#      - "traefik.http.routers.api.middlewares=api_auth"
+#      - "traefik.http.routers.api.middlewares=api_ipallowlist"
+#      - "traefik.http.middlewares.api_auth.basicauth.users=root:$$2y$$05$$X5YxScZkW9geqHY631Mx1.jdbiCLOFSOyLk61c/753RDjCJKuCLvu"
+#      - "traefik.http.middlewares.api_ipallowlist.ipallowlist.sourcerange=127.0.0.1/32, 10.48.17.64/26, 10.48.17.128/25"
+      - "com.centurylinklabs.watchtower.enable=true"
+volumes:
+  composer_cache:
+
+networks:
+  gitea:
+    external: true


### PR DESCRIPTION
In this MR, all the changes that have been done during the WSFR 48 competition, a few adjustment and a few improvements.
The setup during this competition was as it follows :
- All the competitors were assigned a static IP via the DHCP server, the admins and the competitors were on differents VLANs and so different subnets
- Traefik ip allow list filter were added to block Competitor 1 to access Competitor 2 modules but still allows admins to access them
- The system that managed the timers and added times developped by Netario was sending API requests to lock repositories after the module timer has ended.
- The containers logs were accessible by the competitor through the same system that managed the timers, in a nutshell, it connects to docker and get the logs of the container named after the module and the competitor.
- Everything was fully local, from the domains (*.server.skill17) to the CA, few changed were done to the scripts to better handle a non-public CA

Everything was done with Gilles GRANGER and Evan JUGE before or during the competition.

